### PR TITLE
makes dart-crypt compatible with Anglura2 v. 3.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crypt
-version: 1.0.2
+version: 1.0.3
 description: One-way string hashing for salted passwords using the Unix crypt format
 homepage: https://github.com/hoylen/dart-crypt
 author: Hoylen Sue <hoylen@hoylen.com>
@@ -8,4 +8,4 @@ environment:
 dev_dependencies:
   test: "^0.12.10"
 dependencies:
-  crypto: ">=0.9.0 <2.0.0" # Note: until they get upgraded, this needs to co-exist with packages that depend on 0.x.x versions
+  crypto: ">=0.9.0 <=2.0.1" # Note: until they get upgraded, this needs to co-exist with packages that depend on 0.x.x versions


### PR DESCRIPTION
bumps upper bound for crypto to make it  compatible with Anglura2 v. 3.1  
(tests are passing)